### PR TITLE
Remove unused “is_fullaccess” for login and LoggedInUser model. Set activity return type.

### DIFF
--- a/app/src/main/java/com/dialogapp/dialog/auth/PlainTokenAuthenticator.kt
+++ b/app/src/main/java/com/dialogapp/dialog/auth/PlainTokenAuthenticator.kt
@@ -24,7 +24,7 @@ class PlainTokenAuthenticator @Inject constructor(private val microblogService: 
                 return if (verifiedAccount.error == null) {
                     val user = LoggedInUser(verifiedAccount.token!!, verifiedAccount.fullName!!,
                             verifiedAccount.username!!, verifiedAccount.gravatarUrl!!,
-                            verifiedAccount.hasSite!!, verifiedAccount.isFullaccess!!, verifiedAccount.defaultSite!!)
+                            verifiedAccount.hasSite!!, verifiedAccount.defaultSite!!)
                     Resource.success(user)
                 } else {
                     Resource.error("Invalid token", null)

--- a/app/src/main/java/com/dialogapp/dialog/auth/SessionManager.kt
+++ b/app/src/main/java/com/dialogapp/dialog/auth/SessionManager.kt
@@ -35,7 +35,7 @@ class SessionManager @Inject constructor(private val prefs: SharedPreferences,
         if (token != null) {
             user = LoggedInUser(token, prefs.getString(KEY_USER_FULLNAME, "")!!,
                     prefs.getString(KEY_USER_USERNAME, "")!!, prefs.getString(KEY_USER_AVATAR, "")!!,
-                    prefs.getBoolean(KEY_USER_HASSITE, false), prefs.getBoolean(KEY_USER_FULLACCESS, false),
+                    prefs.getBoolean(KEY_USER_HASSITE, false),
                     prefs.getString(KEY_USER_DEFAULTSITE, "")!!)
         }
     }
@@ -48,7 +48,6 @@ class SessionManager @Inject constructor(private val prefs: SharedPreferences,
             putString(KEY_USER_USERNAME, user.username)
             putString(KEY_USER_AVATAR, user.gravatarUrl)
             putBoolean(KEY_USER_HASSITE, user.hasSite)
-            putBoolean(KEY_USER_FULLACCESS, user.isFullaccess)
             putString(KEY_USER_DEFAULTSITE, user.defaultSite)
         }
     }
@@ -76,7 +75,6 @@ class SessionManager @Inject constructor(private val prefs: SharedPreferences,
         private const val KEY_USER_USERNAME = "KEY_USER_USERNAME"
         private const val KEY_USER_AVATAR = "KEY_USER_AVATAR"
         private const val KEY_USER_HASSITE = "KEY_USER_HASSITE"
-        private const val KEY_USER_FULLACCESS = "KEY_USER_FULLACCESS"
         private const val KEY_USER_DEFAULTSITE = "KEY_USER_DEFAULTSITE"
     }
 }

--- a/app/src/main/java/com/dialogapp/dialog/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/dialogapp/dialog/ui/settings/SettingsFragment.kt
@@ -103,6 +103,7 @@ class SettingsFragment : PreferenceFragmentCompat(),
                     ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) ==
                     PackageManager.PERMISSION_GRANTED
         }
+        return false
     }
 
     private fun showMessageAndRequest() {

--- a/app/src/main/java/com/dialogapp/dialog/vo/LoggedInUser.kt
+++ b/app/src/main/java/com/dialogapp/dialog/vo/LoggedInUser.kt
@@ -18,9 +18,6 @@ data class LoggedInUser(
         @Json(name = "has_site")
         val hasSite: Boolean,
 
-        @Json(name = "is_fullaccess")
-        val isFullaccess: Boolean,
-
         @Json(name = "default_site")
         val defaultSite: String
 )


### PR DESCRIPTION
This update removes the unused “is_fullaccess” check during login, which caused a crash in the app as it was force unwrapping it. Also removed other references of this property on the LoggedInUser model as it’s not used anywhere.

Also fixes a slight issue with not setting a return type when using an “activity”, causing build errors.